### PR TITLE
Avoid using dynamic table names in migration

### DIFF
--- a/db/migrations/20170612154112_create_mail_queue_table.php
+++ b/db/migrations/20170612154112_create_mail_queue_table.php
@@ -3,8 +3,6 @@
 use Phinx\Migration\AbstractMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-use Pragma\Dailyrecap\MailQueue;
-
 class CreateMailQueueTable extends AbstractMigration
 {
     /**
@@ -32,7 +30,7 @@ class CreateMailQueueTable extends AbstractMigration
     {
         if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
             $strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-            $t = $this->table(MailQueue::getTableName(), ['id' => false, 'primary_key' => 'id']);
+            $t = $this->table('mail_queue', ['id' => false, 'primary_key' => 'id']);
             switch($strategy){
                 case 'mysql':
                     $t->addColumn('id', 'char', ['limit' => 36]);
@@ -44,7 +42,7 @@ class CreateMailQueueTable extends AbstractMigration
             }
         }
         else{
-            $t = $this->table(MailQueue::getTableName());
+            $t = $this->table('mail_queue');
         }
 
         $t->addColumn('category', 'integer', array('default'=>0))

--- a/db/migrations/20170904152013_update_category_to_string.php
+++ b/db/migrations/20170904152013_update_category_to_string.php
@@ -1,7 +1,6 @@
 <?php
 
 use Phinx\Migration\AbstractMigration;
-use Pragma\Dailyrecap\MailQueue;
 
 class UpdateCategoryToString extends AbstractMigration
 {
@@ -28,13 +27,13 @@ class UpdateCategoryToString extends AbstractMigration
      */
     public function up()
     {
-        $this->table(MailQueue::getTableName())
+        $this->table('mail_queue')
             ->changeColumn('category', 'string', ["default" => null])
             ->update();
     }
     public function down()
     {
-        $this->table(MailQueue::getTableName())
+        $this->table('mail_queue')
             ->changeColumn('category', 'integer', ["default" => 0])
             ->update();
     }

--- a/phinx.php
+++ b/phinx.php
@@ -14,6 +14,7 @@ return array(
             'pass' => DB_PASSWORD,
             'charset' => 'utf8',
             'collation' => 'utf8_general_ci',
+            'table_prefix' => defined('DB_PREFIX') ?  DB_PREFIX : 'pragma_',
         ),
     ),
 );


### PR DESCRIPTION
As class declarations table names might be changed  in further updates,
it would invalidate every previous migrations.