### PR TITLE
Update pear/mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "php": ">=5.3.0",
         "pragma-framework/core": ">=1.0.0",
         "robmorgan/phinx": ">=0.11.1",
-        "pear/mail": "v1.4.1",
-        "pear/mail_mime": "v1.10.2",
+        "pear/mail": ">=v1.4",
+        "pear/mail_mime": ">=v1.10.11",
         "html2text/html2text": "^4.2"
     },
      "autoload": {


### PR DESCRIPTION
Remove deprecated :
Deprecated: preg_replace(): Passing null to parameter #2 ($replacement) of type array|string is deprecated in /Users/corentinlux/www/zentral/backend/vendor/pear/mail/Mail.php on line 155
PHP Deprecated:  preg_replace(): Passing null to parameter #2 ($replacement) of type array|string is deprecated in /Users/corentinlux/www/zentral/backend/vendor/pear/mail/Mail.php on line 155

Deprecated: preg_replace(): Passing null to parameter #2 ($replacement) of type array|string is deprecated in /Users/corentinlux/www/zentral/backend/vendor/pear/mail/Mail.php on line 155
PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/corentinlux/www/zentral/backend/vendor/pear/mail_mime/Mail/mime.php on line 902